### PR TITLE
Update to shimataro/ssh-key-action v2.5.1

### DIFF
--- a/.github/workflows/blt-push-code.yml
+++ b/.github/workflows/blt-push-code.yml
@@ -118,7 +118,7 @@ jobs:
             npm-
 
       - name: Set up the SSH key and configuration.
-        uses: shimataro/ssh-key-action@v2.3.1
+        uses: shimataro/ssh-key-action@v2.5.1
         with:
           key: ${{ secrets.ARTEFACT_SSH_KEY }}
           config: ${{ secrets.SSH_CONFIG }}

--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -116,7 +116,7 @@ jobs:
         if: |
           (inputs.target_key == '' || steps.target-build.outputs.cache-hit != 'true') &&
           inputs.ssh_config
-        uses: shimataro/ssh-key-action@v2.3.1
+        uses: shimataro/ssh-key-action@v2.5.1
         with:
           key: ${{ secrets.SSH_KEY }}
           config: ${{ secrets.SSH_CONFIG }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -114,7 +114,7 @@ jobs:
         if: |
           (inputs.target_key == '' || steps.target-build.outputs.cache-hit != 'true') &&
           inputs.ssh_config
-        uses: shimataro/ssh-key-action@v2.3.1
+        uses: shimataro/ssh-key-action@v2.5.1
         with:
           key: ${{ secrets.SSH_KEY }}
           config: ${{ secrets.SSH_CONFIG }}

--- a/.github/workflows/pantheon-push-code.yml
+++ b/.github/workflows/pantheon-push-code.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 50
 
       - name: Set up the SSH key and configuration.
-        uses: shimataro/ssh-key-action@v2.3.1
+        uses: shimataro/ssh-key-action@v2.5.1
         with:
           key: ${{ secrets.PANTHEON_SSH_KEY }}
           config: ${{ secrets.SSH_CONFIG }}

--- a/.github/workflows/pantheon-remove-branch.yml
+++ b/.github/workflows/pantheon-remove-branch.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up the SSH key and configuration.
-        uses: shimataro/ssh-key-action@v2.3.1
+        uses: shimataro/ssh-key-action@v2.5.1
         with:
           key: ${{ secrets.PANTHEON_SSH_KEY }}
           config: ${{ secrets.SSH_CONFIG }}

--- a/.github/workflows/push-code.yml
+++ b/.github/workflows/push-code.yml
@@ -82,7 +82,7 @@ jobs:
           echo "COMMIT_MSG=`curl -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/commits/$COMMIT_BRANCH | grep '"message":' | grep -oE ': ".*",' | cut -c4- | rev | cut -c3- | rev`" >> $GITHUB_ENV
 
       - name: Set up the SSH key and configuration.
-        uses: shimataro/ssh-key-action@v2.4.0
+        uses: shimataro/ssh-key-action@v2.5.1
         with:
           key: ${{ secrets.ARTEFACT_SSH_KEY }}
           config: ${{ secrets.SSH_CONFIG }}

--- a/.github/workflows/push-code.yml
+++ b/.github/workflows/push-code.yml
@@ -82,7 +82,7 @@ jobs:
           echo "COMMIT_MSG=`curl -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/commits/$COMMIT_BRANCH | grep '"message":' | grep -oE ': ".*",' | cut -c4- | rev | cut -c3- | rev`" >> $GITHUB_ENV
 
       - name: Set up the SSH key and configuration.
-        uses: shimataro/ssh-key-action@v2.3.1
+        uses: shimataro/ssh-key-action@v2.4.0
         with:
           key: ${{ secrets.ARTEFACT_SSH_KEY }}
           config: ${{ secrets.SSH_CONFIG }}

--- a/.github/workflows/push-git.yml
+++ b/.github/workflows/push-git.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 50
 
       - name: Set up the SSH key and configuration
-        uses: shimataro/ssh-key-action@v2.3.1
+        uses: shimataro/ssh-key-action@v2.5.1
         with:
           key: ${{ secrets.TARGET_SSH_KEY }}
           config: ${{ secrets.SSH_CONFIG }}


### PR DESCRIPTION
The old version (v2.3.1) was causing a warning about using an old version of node.

v2.4.0 is where this is addressed, but if we're updating we might as well get the latest. Tested on SWBS and works (tested with `drupal-php-node:p8.0-cli-n8` and `drupal-php-node:p8.0-cli-n16`).

<img width="1439" alt="Screenshot 2023-04-14 at 12 44 34" src="https://user-images.githubusercontent.com/115468450/232035336-a43f8502-2ed0-481d-bacc-3f785f3da320.png">
