### PR TITLE
Set a default value for 'add_files' to add all files.

### DIFF
--- a/.github/workflows/push-code.yml
+++ b/.github/workflows/push-code.yml
@@ -21,6 +21,7 @@ on:
       add_files:
         description: 'The files/directories to add, bypassing .gitignore'
         type: string
+        default: '-A'
     secrets:
       ARTEFACT_REPO:
         description: 'URL of the artefact repo.'


### PR DESCRIPTION
The input is not required and if left empty, it just results in the `git add -f {{ inputs.add_files }}` not adding anything.