### PR TITLE
Create Acquia database backup workflow using ACLI

### DIFF
--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -43,13 +43,12 @@ jobs:
         run: |
           curl -OL https://github.com/acquia/cli/releases/2.13.0/download/acli.phar
           chmod +x acli.phar
-          mv acli.phar /usr/local/bin/acli
           echo "ACLI downloaded!"
 
       - name: Authorizing with ACLI
         id: acli_auth
         run: |
-          acli auth:login -n \
+          acli.phar auth:login -n \
             --key=${{ secrets.ACLI_CLIENT_ID }} \
             --secret=${{ secrets.ACLI_CLIENT_SECRET }}
 
@@ -58,7 +57,7 @@ jobs:
         # Gets databases filtering by a name. If no filter is provided, it'll
         # retrieve all databases.
         run: |
-          acli api:environments:database-list \
+          acli.phar api:environments:database-list \
             --filter="${{ inputs.filter }}" \
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name' >> $GITHUB_OUPUT
@@ -66,7 +65,7 @@ jobs:
       - name: Backing up databases
         run: |
           while read database; do \
-            acli api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database \
+            acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database \
               && echo "💧 Successfully backed up database $database!" \
               || echo "❌ Error backing up database $database. See logs."; exit 1 \
           done <${{ steps.get_databases.outputs.databases }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -70,8 +70,9 @@ jobs:
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name')"
-          echo 'var<<EOF' >> $GITHUB_OUTPUT
+          echo "<<$EOF" >> $GITHUB_OUTPUT
           echo ${database_list} >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -70,10 +70,10 @@ jobs:
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name')"
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "text<<$EOF" >> $GITHUB_OUTPUT
+          delimiter="$(openssl rand -hex 8)"
+          echo "output-name<<${delimiter}" >> "${GITHUB_OUTPUT}"
           echo ${database_list} >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -73,7 +73,7 @@ jobs:
             | jq '.[] | .name')
 
           delimiter="$(openssl rand -hex 8)"
-          echo "output-name<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo "db-list<<${delimiter}" >> "${GITHUB_OUTPUT}"
           echo ${database_list} >> ${GITHUB_OUTPUT}
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
@@ -83,9 +83,7 @@ jobs:
       - name: Backing up databases
         run: |
           echo "DB import start"
-          echo ${{ steps.get_databases.outputs.c_test }}
-          echo ${{ steps.get_databases.outputs.output-name }}
-          echo database
+          echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
           while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -85,8 +85,7 @@ jobs:
           # Loop through the array of databases and attempt to 
           # perform a backup for each database.
           i=0
-          while [ $i -lt ${#backup_array[@]} ]
-          do
+          while [ $i -lt ${#backup_array[@]} ]; do
             php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${backup_array[$i]}
             echo "💧 Successfully backed up database "${backup_array[$i]}"." || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
             i=$((i + 1))

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -66,22 +66,22 @@ jobs:
           echo ${database_pre_list}
           echo "DB list end"
 
-          database_list=$(php acli.phar api:environments:database-list \
+          echo "database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name')
-
+            | jq '.[] | .name')"
           delimiter="$(openssl rand -hex 8)"
           echo "output-name<<${delimiter}" >> "${GITHUB_OUTPUT}"
           echo ${database_list} >> ${GITHUB_OUTPUT}
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
-
-          echo "database_list=$database_list" >> $GITHUB_OUTPUT
+          c_test="Hello world"
+          echo "c_test=$c_test" >> $GITHUB_OUTPUT
 
       - name: Backing up databases
         run: |
           echo "DB import start"
-          echo ${{ steps.get_databases.outputs.database_list }}
+          echo ${{ steps.get_databases.outputs.c_test }}
+          echo ${database_list}
           echo "DB import end"
           echo $database_list
           while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -58,10 +58,10 @@ jobs:
         # Gets databases filtering by a name. If no filter is provided, it'll
         # retrieve all databases.
         run: |
-          php acli.phar api:environments:database-list \
+          database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
-            ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name'
+            ${{ secrets.ENVIRONMENT_ID }}
+          echo ${database_list}
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -87,6 +87,6 @@ jobs:
           echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
-          while read database; do \
-            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
-          done <(split ${{ steps.get_databases.outputs.db-list }} by space)
+          # while read database; do \
+          #   php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
+          # done <(split ${{ steps.get_databases.outputs.db-list }} by space)

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -93,9 +93,8 @@ jobs:
           #Read the split words into an array based on space delimiter
           read -a strarr <<< ${{ steps.get_databases.outputs.db-list }}
 
-          for val in "${strarr[@]}";
-          do
-            printf "$val\n"
+          for val in "${strarr[@]}"; do
+            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $val && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1
           done
 
           # while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -83,22 +83,17 @@ jobs:
 
       - name: Backing up databases
         run: |
-          echo "DB import start"
-          echo ${{ steps.get_databases.outputs.db-list }}
-          echo "DB import end"
 
-          IFS=', ' read -r -a array <<< "${{ steps.get_databases.outputs.db-list }}"
-          echo "Item 1"
-          echo "${array[0]}"
-          echo "Item 2"
-          echo "${array[1]}"
+          # Split db-list into an array.
+          IFS=', ' read -r -a db_array <<< "${{ steps.get_databases.outputs.db-list }}"
 
+          # Loop through the array.
           i=0
-          while [ $i -lt ${#array[@]} ]
+          while [ $i -lt ${#db_array[@]} ]
           do
-            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${array[$i]} && echo "💧 Successfully backed up database ${array[$i]}!" || echo "❌ Error backing up database ${array[$i]}. See logs."; exit 1 \
-            echo "${array[$i]}"
-            echo ".."
+            # php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${array[$i]} && echo "💧 Successfully backed up database ${array[$i]}!" || echo "❌ Error backing up database ${array[$i]}. See logs."; exit 1 \
+            echo "${db_array[$i]}"
+            echo "."
             i=$((i + 1))
           done
 

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -61,7 +61,7 @@ jobs:
           php acli.phar api:environments:database-list \
             --filter="${{ inputs.filter }}" \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name' >> $GITHUB_OUPUT
+            | jq '.[] | .name' >> "$GITHUB_OUPUT"
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -61,8 +61,11 @@ jobs:
           echo "database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
+            | jq '.[] | .name')"
+          echo "database_list=$(php acli.phar api:environments:database-list \
+            --filter='${{ inputs.filter }}' \
+            ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name')" >> "$GITHUB_OUTPUT"
-          echo "DB list [$database_list]"
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -87,16 +87,15 @@ jobs:
           echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
-          # Set space as the delimiter
-          IFS=' '
-
-          #Read the split words into an array based on space delimiter
-          read -a strarr <<< ${{ steps.get_databases.outputs.db-list }}
-
-          for val in "${strarr[@]}"; do
-            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $val && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1
+          db_array=(${{ steps.get_databases.outputs.db-list }})
+          i=0
+          len=${#db_array[@]}
+          while [ $i -lt $len ];
+          do
+              echo ${db_array[$i]}
+              let i++
           done
 
           # while read database; do \
           #   php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
-          # done <(split ${{ steps.get_databases.outputs.db-list }} by space)
+          # done < (split ${{ steps.get_databases.outputs.db-list }} by space)

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -72,13 +72,13 @@ jobs:
             | jq '.[] | .name')"
           delimiter="$(openssl rand -hex 8)"
           echo "output-name<<${delimiter}" >> "${GITHUB_OUTPUT}"
-          echo ${database_list} >> $GITHUB_OUTPUT
+          echo ${database_list} >> ${GITHUB_OUTPUT}
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
       - name: Backing up databases
         run: |
           echo "DB import start"
-          echo ${database_list}
+          echo $GITHUB_OUTPUT['database_list']
           echo "DB import end"
           echo $database_list
           while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -34,6 +34,9 @@ jobs:
     outputs:
       databases: ${{ steps.get_databases.outputs.databases }}
     steps:
+      - name: Checking out code
+        uses: actions/checkout@v3
+
       - name: Installing PHP
         uses: shivammathur/setup-php@master
         with:
@@ -42,11 +45,9 @@ jobs:
       - name: Installing dependencies
         run: |
           curl -OL https://github.com/acquia/cli/releases/2.13.0/download/acli.phar
-          chmod +x acli.phar
           echo "ACLI downloaded!"
 
       - name: Authorizing with ACLI
-        id: acli_auth
         run: |
           acli.phar auth:login -n \
             --key=${{ secrets.ACLI_CLIENT_ID }} \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -70,7 +70,8 @@ jobs:
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name')"
-          echo "<<$EOF" >> $GITHUB_OUTPUT
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "text<<$EOF" >> $GITHUB_OUTPUT
           echo ${database_list} >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -96,6 +96,7 @@ jobs:
           i=0
           while [ $i -lt ${#array[@]} ]
           do
+            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${array[$i]} && echo "💧 Successfully backed up database ${array[$i]}!" || echo "❌ Error backing up database ${array[$i]}. See logs."; exit 1 \
             echo "${array[$i]}"
             echo ".."
             i=$((i + 1))

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -3,10 +3,6 @@ name: Workflow to backup databases on Acquia.
 on:
   workflow_call:
     inputs:
-      environment_id:
-        description: 'Acquia environment ID.'
-        type: string
-        required: true
       filter:
         description: 'Optionally, provide a filter for the databases. See: https://docs.acquia.com/acquia-cli/commands/#api-environments-database-list'
         type: string
@@ -17,6 +13,9 @@ on:
         required: false
         default: '8.2'
     secrets:
+      ENVIRONMENT_ID:
+        description: 'Acquia environment ID.'
+        required: true
       ACLI_CLIENT_ID:
         description: 'The client ID for authenticating with ACLI.'
         required: true
@@ -63,13 +62,13 @@ jobs:
         run: |
           acli api:environments:database-list \
             --filter="${{ inputs.filter }}" \
-            ${{ inputs.environment_id }} \
+            ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name' >> $GITHUB_OUPUT
 
       - name: Backing up databases
         run: |
           while read database; do \
-            acli api:environments:database-backup-create ${{ inputs.environment_id }} $database \
+            acli api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database \
               && echo "💧 Successfully backed up database $database!" \
-              || echo "❌ Error backing up database $database. See logs." \
+              || echo "❌ Error backing up database $database. See logs."; exit 1 \
           done <${{ steps.get_databases.outputs.databases }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -87,12 +87,21 @@ jobs:
           echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
-
           IFS=', ' read -r -a array <<< "${{ steps.get_databases.outputs.db-list }}"
           echo "Item 1"
           echo "${array[0]}"
           echo "Item 2"
           echo "${array[1]}"
+
+          i=0
+          len=${#array[@]}
+          while [ $i -lt $len ];
+          do
+              echo ${array[$i]}
+              echo ".."
+              let i++
+          done
+
 
           # while read db_list; do \
           #   php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $db_list && echo "💧 Successfully backed up database $db_list!" || echo "❌ Error backing up database $db_list. See logs."; exit 1 \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Authorizing with ACLI
         run: |
           php acli.phar auth:login -n \
-            --key=${{ secrets.ACLI_CLIENT_ID }} \
-            --secret=${{ secrets.ACLI_CLIENT_SECRET }}
+            --key="${{ secrets.ACLI_CLIENT_ID }}" \
+            --secret="${{ secrets.ACLI_CLIENT_SECRET }}"
 
       - name: Retrieving all database names for this environment
         id: get_databases

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -65,7 +65,6 @@ jobs:
 
       - name: Backing up databases
         run: |
-          echo $database_list
           while read database; do \
             php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
           done <${{ steps.get_databases.outputs.databases }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -85,7 +85,11 @@ jobs:
           # perform a backup for each database.
           i=0
           while [ $i -lt ${#backup_array[@]} ]; do
-            php acli.phar api:environments:database-backup-create --no-interaction ${{ secrets.ENVIRONMENT_ID }} ${backup_array[$i]}
-            echo "💧 Successfully backed up database "${backup_array[$i]}"." || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
+            php acli.phar api:environments:database-backup-create \
+              --no-interaction \
+              ${{ secrets.ENVIRONMENT_ID }} \
+              ${backup_array[$i]}
+            echo "💧 Successfully backed up database "${backup_array[$i]}"." \
+              || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
             i=$((i + 1))
           done

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -61,7 +61,7 @@ jobs:
           php acli.phar api:environments:database-list \
             --filter="${{ inputs.filter }}" \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name' >> "$GITHUB_OUPUT"
+            | jq '.[] | .name' >> "$GITHUB_OUTPUT"
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -1,0 +1,75 @@
+name: Workflow to backup databases on Acquia.
+
+on:
+  workflow_call:
+    inputs:
+      environment_id:
+        description: 'Acquia environment ID.'
+        type: string
+        required: true
+      filter:
+        description: 'Optionally, provide a filter for the databases. See: https://docs.acquia.com/acquia-cli/commands/#api-environments-database-list'
+        type: string
+        required: false
+      php_version:
+        description: 'Optionally, specify a PHP version to install. Default: 8.2.'
+        type: string
+        required: false
+        default: '8.2'
+    secrets:
+      ACLI_CLIENT_ID:
+        description: 'The client ID for authenticating with ACLI.'
+        required: true
+      ACLI_CLIENT_SECRET:
+        description: 'The client secret for authenticating with ACLI.'
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  backup-databases:
+    name: 'Backup Acquia databases'
+    runs-on: ubuntu-latest
+    outputs:
+      databases: ${{ steps.get_databases.outputs.databases }}
+    steps:
+      - name: Installing PHP
+        uses: shivammathur/setup-php@master
+        with:
+          php-version: ${{ inputs.php_version }}
+
+      - name: Installing dependencies
+        # JQ allows us to filter out results from the ACLI command.
+        run: |
+          curl -OL https://github.com/acquia/cli/releases/2.13.0/download/acli.phar
+          chmod +x acli.phar
+          echo "ACLI downloaded!"
+          sudo apt-get install -y jq
+          echo "JQ installed!"
+
+      - name: Authorizing with ACLI
+        id: acli_auth
+        run: |
+          acli auth:login -n \
+            --key=${{ secrets.ACLI_CLIENT_ID }} \
+            --secret=${{ secrets.ACLI_CLIENT_SECRET }}
+
+      - name: Retrieving all database names for this environment
+        id: get_databases
+        # Gets databases filtering by a name. If no filter is provided, it'll
+        # retrieve all databases.
+        run: |
+          acli api:environments:database-list \
+            --filter="${{ inputs.filter }}" \
+            ${{ inputs.environment_id }} \
+            | jq '.[] | .name' >> $GITHUB_OUPUT
+
+      - name: Backing up databases
+        run: |
+          while read database; do \
+            acli api:environments:database-backup-create ${{ inputs.environment_id }} $database \
+              && echo "💧 Successfully backed up database $database!" \
+              || echo "❌ Error backing up database $database. See logs." \
+          done <${{ steps.get_databases.outputs.databases }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -88,6 +88,6 @@ jobs:
           while [ $i -lt ${#backup_array[@]} ]
           do
             php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${backup_array[$i]}
-            echo "💧 Successfully backed up database "${backup_array[$i]}"" || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
+            echo "💧 Successfully backed up database "${backup_array[$i]}"." || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
             i=$((i + 1))
           done

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -32,7 +32,7 @@ jobs:
     name: 'Backup Acquia databases'
     runs-on: ubuntu-latest
     outputs:
-      databases: ${{ steps.get_databases.outputs.databases }}
+      databases: ${{ steps.get_databases.outputs.database_list }}
     steps:
       - name: Checking out code
         uses: actions/checkout@v3
@@ -58,10 +58,10 @@ jobs:
         # Gets databases filtering by a name. If no filter is provided, it'll
         # retrieve all databases.
         run: |
-          php acli.phar api:environments:database-list \
-            --filter="${{ inputs.filter }}" \
+          echo "database_list=$(php acli.phar api:environments:database-list \
+            --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name' >> "$GITHUB_OUTPUT"
+            | jq '.[] | .name')" >> "$GITHUB_OUTPUT"
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       databases: ${{ steps.get_databases.outputs.database_list }}
-      db_list: ${{ steps.get_databases.outputs.db-list }}
+      db_list: ${{ steps.get_databases.outputs.db_list }}
     steps:
       - name: Checking out code
         uses: actions/checkout@v3
@@ -59,44 +59,40 @@ jobs:
         # Gets databases filtering by a name. If no filter is provided, it'll
         # retrieve all databases.
         run: |
+          # The first time we run api:environments:database-list acli very
+          # kindly also outputs a string asking the user to share
+          # anonymous user data along with the JSON output causing error
+          # further down the chain - this simply mitigates that.
           acsf_request=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             --limit='1' \
             ${{ secrets.ENVIRONMENT_ID }})
 
-          echo "DB list start"
-          echo ${acsf_request}
-          echo "DB list end"
-
+          # Gets a list of databases and uses jq to filter the output
+          # to the name value only.
           database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name')
 
+          # Processes the output of databases.
           delimiter="$(openssl rand -hex 8)"
-          echo "db-list<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo "db_list<<${delimiter}" >> "${GITHUB_OUTPUT}"
           echo ${database_list} >> ${GITHUB_OUTPUT}
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
-
-          c_test="Hello world"
-          echo "c_test=$c_test" >> $GITHUB_OUTPUT
 
       - name: Backing up databases
         run: |
 
-          # Split db-list into an array.
-          IFS=', ' read -r -a db_array <<< "${{ steps.get_databases.outputs.db-list }}"
+          # Split db_list into an array.
+          IFS=', ' read -r -a db_array <<< "${{ steps.get_databases.outputs.db_list }}"
 
-          # Loop through the array.
+          # Loop through the array of databases and attempt to 
+          # perform a backup for each database.
           i=0
           while [ $i -lt ${#db_array[@]} ]
           do
             php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${db_array[$i]}
-            echo "${db_array[$i]}"
+            echo "💧 Successfully backed up database "${db_array[$i]}"" || echo "❌ Error backing up database $db_list. See logs."
             i=$((i + 1))
           done
-
-
-          # while read db_list; do \
-          #   php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $db_list && echo "💧 Successfully backed up database $db_list!" || echo "❌ Error backing up database $db_list. See logs."; exit 1 \
-          # done <${{ steps.get_databases.outputs.db-list }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           echo "DB import start"
           echo ${{ steps.get_databases.outputs.c_test }}
-          echo ${{ steps.get_databases.outputs.database_list }}
+          echo ${{ steps.get_databases.outputs.output-name }}
           echo database
           echo "DB import end"
 

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -91,7 +91,7 @@ jobs:
           i=0
           while [ $i -lt ${#db_array[@]} ]
           do
-            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${db_array[$i]} && echo "💧 Successfully backed up database ${db_array[$i]}" || echo "❌ Error backing up database ${db_array[$i]}. See logs."; exit 1 \
+            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${db_array[$i]}
             echo "${db_array[$i]}"
             i=$((i + 1))
           done

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -61,10 +61,6 @@ jobs:
           echo "database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name')"
-          echo "database_list=$(php acli.phar api:environments:database-list \
-            --filter='${{ inputs.filter }}' \
-            ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name')" >> "$GITHUB_OUTPUT"
 
       - name: Backing up databases

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -61,7 +61,7 @@ jobs:
           echo "database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq -r '.[] | .name')" >> "$GITHUB_OUTPUT"
+            | jq '.[] | .name')" >> "$GITHUB_OUTPUT"
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -61,7 +61,6 @@ jobs:
           database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }})
-          echo ${database_list}
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -69,7 +69,7 @@ jobs:
           database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name')
+            | jq -r '.[] | .name')
           delimiter="$(openssl rand -hex 8)"
           echo "output-name<<${delimiter}" >> "${GITHUB_OUTPUT}"
           echo ${database_list} >> ${GITHUB_OUTPUT}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -66,7 +66,5 @@ jobs:
       - name: Backing up databases
         run: |
           while read database; do \
-            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database \
-              && echo "💧 Successfully backed up database $database!" \
-              || echo "❌ Error backing up database $database. See logs."; exit 1 \
+            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
           done <${{ steps.get_databases.outputs.databases }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Backing up databases
         run: |
           echo "DB import start"
-          echo $GITHUB_OUTPUT['database_list']
+          echo ${{ steps.get_databases.outputs.databases }}
           echo "DB import end"
           echo $database_list
           while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -58,33 +58,27 @@ jobs:
         # Gets databases filtering by a name. If no filter is provided, it'll
         # retrieve all databases.
         run: |
-          database_pre_list=$(php acli.phar api:environments:database-list \
+          acsf_request=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
-            --limit='5' \
+            --limit='1' \
             ${{ secrets.ENVIRONMENT_ID }})
+
           echo "DB list start"
-          echo ${database_pre_list}
+          echo ${acsf_request}
           echo "DB list end"
 
           database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq -r '.[] | .name')
-          delimiter="$(openssl rand -hex 8)"
-          echo "output-name<<${delimiter}" >> "${GITHUB_OUTPUT}"
-          echo ${database_list} >> ${GITHUB_OUTPUT}
-          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
-          c_test="Hello world"
-          echo "c_test=$c_test" >> $GITHUB_OUTPUT
-          echo "database_list_2=$database_list" >> $GITHUB_OUTPUT
+            | jq '.[] | .name')
 
       - name: Backing up databases
         run: |
           echo "DB import start"
           echo ${{ steps.get_databases.outputs.c_test }}
-          echo ${{ steps.get_databases.outputs.database_list_2 }}
+          echo database
           echo "DB import end"
-          echo $database_list
+
           while read database; do \
             php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
           done <${{ steps.get_databases.outputs.databases }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -77,6 +77,9 @@ jobs:
 
       - name: Backing up databases
         run: |
+          echo "DB import start"
+          echo ${database_list}
+          echo "DB import end"
           echo $database_list
           while read database; do \
             php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -85,7 +85,11 @@ jobs:
           # perform a backup for each database.
           i=0
           while [ $i -lt ${#backup_array[@]} ]; do
-            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${backup_array[$i]}
-            echo "💧 Successfully backed up database "${backup_array[$i]}"." || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
+            php acli.phar api:environments:database-backup-create \
+              --no-interaction \ 
+              ${{ secrets.ENVIRONMENT_ID }} \ 
+              ${backup_array[$i]} \ 
+              && echo "💧 Successfully backed up database "${backup_array[$i]}"." \ 
+              || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
             i=$((i + 1))
           done

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -61,7 +61,9 @@ jobs:
           database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }})
+          echo "DB list start"
           echo ${database_list}
+          echo "DB list end"
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -66,21 +66,22 @@ jobs:
           echo ${database_pre_list}
           echo "DB list end"
 
-          echo "database_list=$(php acli.phar api:environments:database-list \
+          database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name')"
+            | jq '.[] | .name')
+
           delimiter="$(openssl rand -hex 8)"
           echo "output-name<<${delimiter}" >> "${GITHUB_OUTPUT}"
           echo ${database_list} >> ${GITHUB_OUTPUT}
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
-          c_test="Hello world"
-          echo "c_test=$c_test" >> $GITHUB_OUTPUT
+
+          echo "database_list=$database_list" >> $GITHUB_OUTPUT
 
       - name: Backing up databases
         run: |
           echo "DB import start"
-          echo ${{ steps.get_databases.outputs.c_test }}
+          echo ${{ steps.get_databases.outputs.database_list }}
           echo "DB import end"
           echo $database_list
           while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -65,8 +65,16 @@ jobs:
           echo ${database_list}
           echo "DB list end"
 
+          database_list_2=$(php acli.phar api:environments:database-list \
+            --filter='${{ inputs.filter }}' \
+            ${{ secrets.ENVIRONMENT_ID }})
+          echo "DB list 2 start"
+          echo ${database_list_2}
+          echo "DB list 2 end"
+
       - name: Backing up databases
         run: |
+          echo $database_list
           while read database; do \
             php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
           done <${{ steps.get_databases.outputs.databases }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -85,7 +85,7 @@ jobs:
           # perform a backup for each database.
           i=0
           while [ $i -lt ${#backup_array[@]} ]; do
-            php acli.phar api:environments:database-backup-create \
+            php acli.phar api:environments:database-backup-create \ 
               --no-interaction \ 
               ${{ secrets.ENVIRONMENT_ID }} \ 
               ${backup_array[$i]} \ 

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -87,6 +87,14 @@ jobs:
           echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
+          while read db_listing; do \
+            echo "DB" \
+          done <${{ steps.get_databases.outputs.db-list }}
+
+          echo "DB import 2 start"
+          echo db_list
+          echo "DB import 2 end"
+
           while read database; do \
             php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
           done <${{ steps.get_databases.outputs.databases }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -62,6 +62,7 @@ jobs:
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq -r '.[] | .name')" >> "$GITHUB_OUTPUT"
+          echo $database_list
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -91,9 +91,8 @@ jobs:
           i=0
           while [ $i -lt ${#db_array[@]} ]
           do
-            # php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${array[$i]} && echo "💧 Successfully backed up database ${array[$i]}!" || echo "❌ Error backing up database ${array[$i]}. See logs."; exit 1 \
+            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${db_array[$i]} && echo "💧 Successfully backed up database ${db_array[$i]}" || echo "❌ Error backing up database ${db_array[$i]}. See logs."; exit 1 \
             echo "${db_array[$i]}"
-            echo "."
             i=$((i + 1))
           done
 

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -87,6 +87,9 @@ jobs:
           echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
-          while read db_list; do \
-            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $db_list && echo "💧 Successfully backed up database $db_list!" || echo "❌ Error backing up database $db_list. See logs."; exit 1 \
-          done < (split ${{ steps.get_databases.outputs.db-list }} by space)
+
+
+
+          # while read db_list; do \
+          #   php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $db_list && echo "💧 Successfully backed up database $db_list!" || echo "❌ Error backing up database $db_list. See logs."; exit 1 \
+          # done <${{ steps.get_databases.outputs.db-list }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -62,7 +62,7 @@ jobs:
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq -r '.[] | .name')
-          echo ${database_list}
+          echo $database_list
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -40,13 +40,11 @@ jobs:
           php-version: ${{ inputs.php_version }}
 
       - name: Installing dependencies
-        # JQ allows us to filter out results from the ACLI command.
         run: |
           curl -OL https://github.com/acquia/cli/releases/2.13.0/download/acli.phar
           chmod +x acli.phar
+          mv acli.phar /usr/local/bin/acli
           echo "ACLI downloaded!"
-          sudo apt-get install -y jq
-          echo "JQ installed!"
 
       - name: Authorizing with ACLI
         id: acli_auth

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -82,8 +82,10 @@ jobs:
 
       - name: Backing up databases
         run: |
+
+          dbs=${{ steps.get_databases.outputs.db-list }}
           echo "DB import start"
-          echo ${{ steps.get_databases.outputs.db-list }}
+          echo $dbs
           echo "DB import end"
 
           while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -85,11 +85,7 @@ jobs:
           # perform a backup for each database.
           i=0
           while [ $i -lt ${#backup_array[@]} ]; do
-            php acli.phar api:environments:database-backup-create \ 
-              --no-interaction \ 
-              ${{ secrets.ENVIRONMENT_ID }} \ 
-              ${backup_array[$i]} \ 
-              echo "💧 Successfully backed up database "${backup_array[$i]}"." \ 
-              || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
+            php acli.phar api:environments:database-backup-create --no-interaction ${{ secrets.ENVIRONMENT_ID }} ${backup_array[$i]}
+            echo "💧 Successfully backed up database "${backup_array[$i]}"." || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
             i=$((i + 1))
           done

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -76,12 +76,13 @@ jobs:
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
           c_test="Hello world"
           echo "c_test=$c_test" >> $GITHUB_OUTPUT
+          echo "database_list_2=$database_list" >> $GITHUB_OUTPUT
 
       - name: Backing up databases
         run: |
           echo "DB import start"
           echo ${{ steps.get_databases.outputs.c_test }}
-          echo ${{ steps.get_databases.outputs.database_list }}
+          echo ${{ steps.get_databases.outputs.database_list_2 }}
           echo "DB import end"
           echo $database_list
           while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -61,6 +61,7 @@ jobs:
           database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }})
+          echo ${database_list}
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -66,10 +66,10 @@ jobs:
           echo ${database_pre_list}
           echo "DB list end"
 
-          echo "database_list=$(php acli.phar api:environments:database-list \
+          database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name')"
+            | jq '.[] | .name')
           delimiter="$(openssl rand -hex 8)"
           echo "output-name<<${delimiter}" >> "${GITHUB_OUTPUT}"
           echo ${database_list} >> ${GITHUB_OUTPUT}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -96,7 +96,8 @@ jobs:
           i=0
           while [ $i -lt ${#array[@]} ]
           do
-            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${array[$i]} && echo "💧 Successfully backed up database ${array[$i]}!" || echo "❌ Error backing up database ${array[$i]}. See logs."; exit 1 \
+            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${array[$i]} \
+            echo "💧 Successfully backed up database ${array[$i]}!"
             echo "${array[$i]}"
             echo ".."
             i=$((i + 1))

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           # The first time we run api:environments:database-list acli very
           # kindly also outputs a string asking the user to share
-          # anonymous user data along with the JSON output causing error
+          # anonymous user data along with the JSON output causing an error
           # further down the chain - this simply mitigates that.
           acsf_request=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
@@ -75,7 +75,8 @@ jobs:
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name')
 
-          # Processes the output of databases.
+          # Processes the output of databases to allow the data to
+          # be passed to the 'Backing up databases' step.
           delimiter="$(openssl rand -hex 8)"
           echo "db_list<<${delimiter}" >> "${GITHUB_OUTPUT}"
           echo ${database_list} >> ${GITHUB_OUTPUT}
@@ -85,14 +86,14 @@ jobs:
         run: |
 
           # Split db_list into an array.
-          IFS=', ' read -r -a db_array <<< "${{ steps.get_databases.outputs.db_list }}"
+          IFS=', ' read -r -a backup_array <<< "${{ steps.get_databases.outputs.db_list }}"
 
           # Loop through the array of databases and attempt to 
           # perform a backup for each database.
           i=0
-          while [ $i -lt ${#db_array[@]} ]
+          while [ $i -lt ${#backup_array[@]} ]
           do
-            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${db_array[$i]}
-            echo "💧 Successfully backed up database "${db_array[$i]}"" || echo "❌ Error backing up database $db_list. See logs."
+            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${backup_array[$i]}
+            echo "💧 Successfully backed up database "${backup_array[$i]}"" || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
             i=$((i + 1))
           done

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -87,6 +87,13 @@ jobs:
           echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
-          while read db_list; do \
-            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $db_list && echo "💧 Successfully backed up database $db_list!" || echo "❌ Error backing up database $db_list. See logs."; exit 1 \
-          done <${{ steps.get_databases.outputs.db-list }}
+
+          IFS=', ' read -r -a array <<< "${{ steps.get_databases.outputs.db-list }}"
+          echo "Item 1"
+          echo "${array[0]}"
+          echo "Item 2"
+          echo "${array[1]}"
+
+          # while read db_list; do \
+          #   php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $db_list && echo "💧 Successfully backed up database $db_list!" || echo "❌ Error backing up database $db_list. See logs."; exit 1 \
+          # done <${{ steps.get_databases.outputs.db-list }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Installing dependencies
         run: |
-          curl -OL https://github.com/acquia/cli/releases/2.13.0/download/acli.phar
+          curl -OL https://github.com/acquia/cli/releases/download/2.13.0/acli.phar
           echo "ACLI downloaded!"
 
       - name: Authorizing with ACLI

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -62,6 +62,7 @@ jobs:
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name')" >> "$GITHUB_OUTPUT"
+          echo "DB list [$database_list]"
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -58,10 +58,10 @@ jobs:
         # Gets databases filtering by a name. If no filter is provided, it'll
         # retrieve all databases.
         run: |
-          echo "database_list=$(php acli.phar api:environments:database-list \
+          php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name')" >> "$GITHUB_OUTPUT"
+            | jq '.[] | .name'
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -88,8 +88,8 @@ jobs:
             php acli.phar api:environments:database-backup-create \
               --no-interaction \
               ${{ secrets.ENVIRONMENT_ID }} \
-              ${backup_array[$i]}
-            echo "💧 Successfully backed up database "${backup_array[$i]}"." \
+              ${backup_array[$i]} \
+              && echo "💧 Successfully backed up database "${backup_array[$i]}"." \
               || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
             i=$((i + 1))
           done

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           echo "DB import start"
           echo ${{ steps.get_databases.outputs.c_test }}
+          echo ${{ steps.get_databases.outputs.database_list }}
           echo database
           echo "DB import end"
 

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       filter:
-        description: 'Optionally, provide a filter for the databases. See: https://docs.acquia.com/acquia-cli/commands/#api-environments-database-list'
+        description: 'Optionally, provide a filter for the databases. See: https://docs.acquia.com/acquia-cloud-platform/add-ons/acquia-cli/commands/api:applications:database-list'
         type: string
         required: false
       php_version:
@@ -45,7 +45,7 @@ jobs:
 
       - name: Installing dependencies
         run: |
-          curl -OL https://github.com/acquia/cli/releases/download/2.13.0/acli.phar
+          curl -OL https://github.com/acquia/cli/releases/download/2.24.0/acli.phar
           echo "ACLI downloaded!"
 
       - name: Authorizing with ACLI

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -87,9 +87,6 @@ jobs:
           echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
-
-
-
-          # while read db_list; do \
-          #   php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $db_list && echo "💧 Successfully backed up database $db_list!" || echo "❌ Error backing up database $db_list. See logs."; exit 1 \
-          # done <${{ steps.get_databases.outputs.db-list }}
+          while read db_list; do \
+            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $db_list && echo "💧 Successfully backed up database $db_list!" || echo "❌ Error backing up database $db_list. See logs."; exit 1 \
+          done <${{ steps.get_databases.outputs.db-list }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -89,7 +89,7 @@ jobs:
               --no-interaction \ 
               ${{ secrets.ENVIRONMENT_ID }} \ 
               ${backup_array[$i]} \ 
-              && echo "💧 Successfully backed up database "${backup_array[$i]}"." \ 
+              echo "💧 Successfully backed up database "${backup_array[$i]}"." \ 
               || echo "❌ Error backing up database "${backup_array[$i]}". See logs."
             i=$((i + 1))
           done

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       databases: ${{ steps.get_databases.outputs.database_list }}
+      db_list: ${{ steps.get_databases.outputs.db-list }}
     steps:
       - name: Checking out code
         uses: actions/checkout@v3
@@ -82,10 +83,8 @@ jobs:
 
       - name: Backing up databases
         run: |
-
-          dbs=${{ steps.get_databases.outputs.db-list }}
           echo "DB import start"
-          echo ${dbs}
+          echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
           while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -61,7 +61,7 @@ jobs:
           echo "database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name')" >> "$GITHUB_OUTPUT"
+            | jq -r '.[] | .name')" >> "$GITHUB_OUTPUT"
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -58,11 +58,11 @@ jobs:
         # Gets databases filtering by a name. If no filter is provided, it'll
         # retrieve all databases.
         run: |
-          echo "database_list=$(php acli.phar api:environments:database-list \
+          database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq -r '.[] | .name')" >> "$GITHUB_OUTPUT"
-          echo $database_list
+            | jq -r '.[] | .name')
+          echo ${database_list}
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -72,6 +72,14 @@ jobs:
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name')
 
+          delimiter="$(openssl rand -hex 8)"
+          echo "output-name<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo ${database_list} >> ${GITHUB_OUTPUT}
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+
+          c_test="Hello world"
+          echo "c_test=$c_test" >> $GITHUB_OUTPUT
+
       - name: Backing up databases
         run: |
           echo "DB import start"

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Authorizing with ACLI
         run: |
-          acli.phar auth:login -n \
+          php acli.phar auth:login -n \
             --key=${{ secrets.ACLI_CLIENT_ID }} \
             --secret=${{ secrets.ACLI_CLIENT_SECRET }}
 
@@ -58,7 +58,7 @@ jobs:
         # Gets databases filtering by a name. If no filter is provided, it'll
         # retrieve all databases.
         run: |
-          acli.phar api:environments:database-list \
+          php acli.phar api:environments:database-list \
             --filter="${{ inputs.filter }}" \
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name' >> $GITHUB_OUPUT
@@ -66,7 +66,7 @@ jobs:
       - name: Backing up databases
         run: |
           while read database; do \
-            acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database \
+            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database \
               && echo "💧 Successfully backed up database $database!" \
               || echo "❌ Error backing up database $database. See logs."; exit 1 \
           done <${{ steps.get_databases.outputs.databases }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       databases: ${{ steps.get_databases.outputs.database_list }}
-      db_list: ${{ steps.get_databases.outputs.db_list }}
     steps:
       - name: Checking out code
         uses: actions/checkout@v3
@@ -72,15 +71,15 @@ jobs:
           # Processes the output of databases to allow the data to
           # be passed to the 'Backing up databases' step.
           delimiter="$(openssl rand -hex 8)"
-          echo "db_list<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo "database_list<<${delimiter}" >> "${GITHUB_OUTPUT}"
           echo ${database_list} >> ${GITHUB_OUTPUT}
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
       - name: Backing up databases
         run: |
 
-          # Split db_list into an array.
-          IFS=', ' read -r -a backup_array <<< "${{ steps.get_databases.outputs.db_list }}"
+          # Split database_list into an array.
+          IFS=', ' read -r -a backup_array <<< "${{ steps.get_databases.outputs.database_list }}"
 
           # Loop through the array of databases and attempt to 
           # perform a backup for each database.

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -58,19 +58,17 @@ jobs:
         # Gets databases filtering by a name. If no filter is provided, it'll
         # retrieve all databases.
         run: |
-          database_list=$(php acli.phar api:environments:database-list \
+          database_pre_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }})
           echo "DB list start"
-          echo ${database_list}
+          echo ${database_pre_list}
           echo "DB list end"
 
-          database_list_2=$(php acli.phar api:environments:database-list \
+          echo "database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
-            ${{ secrets.ENVIRONMENT_ID }})
-          echo "DB list 2 start"
-          echo ${database_list_2}
-          echo "DB list 2 end"
+            ${{ secrets.ENVIRONMENT_ID }} \
+            | jq '.[] | .name')" >> "$GITHUB_OUTPUT"
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -87,6 +87,17 @@ jobs:
           echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
+          # Set space as the delimiter
+          IFS=' '
+
+          #Read the split words into an array based on space delimiter
+          read -a strarr <<< ${{ steps.get_databases.outputs.db-list }}
+
+          for val in "${strarr[@]}";
+          do
+            printf "$val\n"
+          done
+
           # while read database; do \
           #   php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
           # done <(split ${{ steps.get_databases.outputs.db-list }} by space)

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
-            ${{ secrets.ENVIRONMENT_ID }}
+            ${{ secrets.ENVIRONMENT_ID }})
           echo ${database_list}
 
       - name: Backing up databases

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -58,14 +58,14 @@ jobs:
         # Gets databases filtering by a name. If no filter is provided, it'll
         # retrieve all databases.
         run: |
-          database_list=$(php acli.phar api:environments:database-list \
+          echo "database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq -r '.[] | .name')
-          echo $database_list
+            | jq -r '.[] | .name')" >> "$GITHUB_OUTPUT"
 
       - name: Backing up databases
         run: |
+          echo $database_list
           while read database; do \
             php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
           done <${{ steps.get_databases.outputs.databases }}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -85,7 +85,7 @@ jobs:
 
           dbs=${{ steps.get_databases.outputs.db-list }}
           echo "DB import start"
-          echo $dbs
+          echo ${dbs}
           echo "DB import end"
 
           while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Backing up databases
         run: |
           echo "DB import start"
-          echo ${{ steps.get_databases.outputs.databases }}
+          echo ${{ steps.get_databases.outputs.database_list }}
           echo "DB import end"
           echo $database_list
           while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -70,6 +70,7 @@ jobs:
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name')"
+          echo "database_list=$database_list" >> $GITHUB_OUTPUT  
           delimiter="$(openssl rand -hex 8)"
           echo "output-name<<${delimiter}" >> "${GITHUB_OUTPUT}"
           echo ${database_list} >> ${GITHUB_OUTPUT}

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -94,12 +94,11 @@ jobs:
           echo "${array[1]}"
 
           i=0
-          len=${#array[@]}
-          while [ $i -lt $len ];
-          do \
-              echo ${array[$i]} \
-              echo ".." \
-              let i++ \
+          while [ $i -lt ${#array[@]} ]
+          do
+            echo "${array[$i]}"
+            echo ".."
+            i=$((i + 1))
           done
 
 

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -87,14 +87,6 @@ jobs:
           echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
-          while read db_listing; do \
-            echo "DB" \
-          done <${{ steps.get_databases.outputs.db-list }}
-
-          echo "DB import 2 start"
-          echo db_list
-          echo "DB import 2 end"
-
           while read database; do \
             php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
-          done <${{ steps.get_databases.outputs.databases }}
+          done <(split ${{ steps.get_databases.outputs.db-list }} by space)

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           database_pre_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
+            --limit='5' \
             ${{ secrets.ENVIRONMENT_ID }})
           echo "DB list start"
           echo ${database_pre_list}
@@ -68,7 +69,9 @@ jobs:
           echo "database_list=$(php acli.phar api:environments:database-list \
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
-            | jq '.[] | .name')" >> "$GITHUB_OUTPUT"
+            | jq '.[] | .name')"
+          echo 'var<<EOF' >> $GITHUB_OUTPUT
+          echo ${database_list} >> $GITHUB_OUTPUT
 
       - name: Backing up databases
         run: |

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -59,14 +59,8 @@ jobs:
         # Gets databases filtering by a name. If no filter is provided, it'll
         # retrieve all databases.
         run: |
-          # The first time we run api:environments:database-list acli very
-          # kindly also outputs a string asking the user to share
-          # anonymous user data along with the JSON output causing an error
-          # further down the chain - this simply mitigates that.
-          acsf_request=$(php acli.phar api:environments:database-list \
-            --filter='${{ inputs.filter }}' \
-            --limit='1' \
-            ${{ secrets.ENVIRONMENT_ID }})
+          # Disable ACLI telemetry
+          disable_acli_telemetry=$(php acli.phar self:telemetry:disable)
 
           # Gets a list of databases and uses jq to filter the output
           # to the name value only.

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -87,15 +87,6 @@ jobs:
           echo ${{ steps.get_databases.outputs.db-list }}
           echo "DB import end"
 
-          db_array=(${{ steps.get_databases.outputs.db-list }})
-          i=0
-          len=${#db_array[@]}
-          while [ $i -lt $len ];
-          do
-              echo ${db_array[$i]}
-              let i++
-          done
-
-          # while read database; do \
-          #   php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $database && echo "💧 Successfully backed up database $database!" || echo "❌ Error backing up database $database. See logs."; exit 1 \
-          # done < (split ${{ steps.get_databases.outputs.db-list }} by space)
+          while read db_list; do \
+            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} $db_list && echo "💧 Successfully backed up database $db_list!" || echo "❌ Error backing up database $db_list. See logs."; exit 1 \
+          done < (split ${{ steps.get_databases.outputs.db-list }} by space)

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -96,10 +96,10 @@ jobs:
           i=0
           len=${#array[@]}
           while [ $i -lt $len ];
-          do
-              echo ${array[$i]}
-              echo ".."
-              let i++
+          do \
+              echo ${array[$i]} \
+              echo ".." \
+              let i++ \
           done
 
 

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -96,8 +96,7 @@ jobs:
           i=0
           while [ $i -lt ${#array[@]} ]
           do
-            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${array[$i]} \
-            echo "💧 Successfully backed up database ${array[$i]}!"
+            php acli.phar api:environments:database-backup-create ${{ secrets.ENVIRONMENT_ID }} ${array[$i]} && echo "💧 Successfully backed up database ${array[$i]}!" || echo "❌ Error backing up database ${array[$i]}. See logs."; exit 1 \
             echo "${array[$i]}"
             echo ".."
             i=$((i + 1))

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -70,16 +70,17 @@ jobs:
             --filter='${{ inputs.filter }}' \
             ${{ secrets.ENVIRONMENT_ID }} \
             | jq '.[] | .name')"
-          echo "database_list=$database_list" >> $GITHUB_OUTPUT  
           delimiter="$(openssl rand -hex 8)"
           echo "output-name<<${delimiter}" >> "${GITHUB_OUTPUT}"
           echo ${database_list} >> ${GITHUB_OUTPUT}
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+          c_test="Hello world"
+          echo "c_test=$c_test" >> $GITHUB_OUTPUT
 
       - name: Backing up databases
         run: |
           echo "DB import start"
-          echo ${{ steps.get_databases.outputs.database_list }}
+          echo ${{ steps.get_databases.outputs.c_test }}
           echo "DB import end"
           echo $database_list
           while read database; do \

--- a/.github/workflows/acquia-backup-databases.yml
+++ b/.github/workflows/acquia-backup-databases.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           echo "DB import start"
           echo ${{ steps.get_databases.outputs.c_test }}
-          echo ${database_list}
+          echo ${{ steps.get_databases.outputs.database_list }}
           echo "DB import end"
           echo $database_list
           while read database; do \


### PR DESCRIPTION
Totally expecting this to need changes :joy: 

* Downloads ACLI: https://docs.acquia.com/acquia-cli/install/ 
  - Also downloads jq, recommended by ACLI, to filter the results from the API requests: https://jqlang.github.io/jq/
* Authenticates with the provided ACLI client ID & secret.
* Retrieves all the databases for the given environment, filters out the name field, and saves it (hopefully) to the output of that step.
  - Will take a filter value which is a real nightmare to get right. I've linked to the docs, but it's still butts to get it right.
* Uses ACLI to trigger a backup for each database.
  - Hoping this will trigger an error/stop? Should I change it to `|| echo "blah"; exit 1`? 🤔 Do I need to update a status?? It's all academical at the moment.

Anyway - feedback appreciated - gonna go over to the WaterAid repo now and create a PR to add this workflow in - will chop and change as needed based on feedback.