### PR TITLE
Fix issues of no history in tag artefact pushes.

### DIFF
--- a/.github/workflows/push-code.yml
+++ b/.github/workflows/push-code.yml
@@ -90,22 +90,31 @@ jobs:
 
       - name: Add & fetch the artefact repo.
         run: |
-          git config --global --add safe.directory $(realpath .)
           git remote add artefact ${{ secrets.ARTEFACT_REPO }}
           git fetch artefact
 
-      - name: Checkout artefact branch without changing local files.
+      - name: Ensure we have an un-shallow fetch.
         if: startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/pull/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
-        # Include an unshallow fetch of origin so that we have history. At some
-        # replace this with trying to build on top of the parent when there
-        # isn't a previous build in the same branch.
+        # At some replace this with trying to build on top of the parent when
+        # there isn't a previous build in the same branch.
         run: |
           git remote set-url origin $(git remote get-url origin | sed 's#https://#https://${{ secrets.GITHUB_TOKEN }}:${{ secrets.GITHUB_TOKEN }}@#')
           git fetch --unshallow origin
+
+      - name: Checkout artefact branch without changing local files.
+        if: startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/pull/')
+        run: |
           git checkout -b ${COMMIT_REF:11}-build
           git reset --soft artefact/${COMMIT_REF:11}-build || true
+
+      - name: Checkout tag's artefact branch without changing local files.
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          rawbranch=$(git branch -r --contains ${COMMIT_REF:10} | grep -Eo 'origin/[^ ]+$' | head -n 1)
+          branch=${rawbranch/origin\/}
+          git reset --soft artefact/${branch}-build || true
 
       - name: Add the build files.
         run: git add -f ${{ inputs.add_files }}


### PR DESCRIPTION
`push-code` has issues with tags, where you get errors like:

```
 ! [remote rejected]     1.12.0-build -> 1.12.0-build (shallow update not allowed)
```

This is because the github repo is a shallow clone, so the tag cannot be pushed as there is no history.

This PR:
- Ensures we have a full clone locally, which means there will always be a history that can be pushed
- When possible, attempts to optimise that history to the relevant build branch for the tag