### PR TITLE
Workflow to deploy to a branch

### DIFF
--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -71,4 +71,4 @@ jobs:
         run: git commit -m "Release ${GITHUB_REF:10}" --allow-empty
 
       - name: Push the changes
-        run: git push
+        run: git push origin ${{ inputs.branch }}

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Check out the code without a token
         uses: actions/checkout@v3
-        if: !secrets.GIT_ACCESS_TOKEN
+        if: secrets.GIT_ACCESS_TOKEN == null
         with:
           fetch-depth: 0
 
@@ -95,7 +95,7 @@ jobs:
         run: git commit -m "Release ${GITHUB_REF:10}" --allow-empty
 
       - name: Push the branch to github
-        if: !secrets.TARGET_REPO
+        if: secrets.TARGET_REPO == null
         run: git push origin ${{ inputs.branch }}
 
       - name: Set up the SSH key and configuration

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Check out the code without a token
         uses: actions/checkout@v3
-        if: ! secrets.GIT_ACCESS_TOKEN
+        if: !secrets.GIT_ACCESS_TOKEN
         with:
           fetch-depth: 0
 
@@ -95,7 +95,7 @@ jobs:
         run: git commit -m "Release ${GITHUB_REF:10}" --allow-empty
 
       - name: Push the branch to github
-        if: ! secrets.TARGET_REPO
+        if: !secrets.TARGET_REPO
         run: git push origin ${{ inputs.branch }}
 
       - name: Set up the SSH key and configuration

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -50,10 +50,9 @@ jobs:
 
       - name: Ensure everything matches before proceeding
         run: |
-          git config --global --add safe.directory $(realpath .) && echo 'config'
-          git diff && echo 'diff'
-          git diff-index HEAD && echo 'diff-index loud'
-          git diff-index --quiet HEAD && echo 'diff-index'
+          git config --global --add safe.directory $(realpath .)
+          git diff ${{ github.sha }}
+          git diff-index --quiet ${{ github.sha }}
 
       - name: Commit the changes if ref is a branch
         if: startsWith(github.ref, 'refs/heads/')

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -7,6 +7,14 @@ on:
         description: 'The target branch'
         type: string
         required: false
+    git_name:
+      description: 'The git committer name'
+      type: string
+      required: true
+    git_email:
+      description: 'The git committer email'
+      type: string
+      required: true
 
 defaults:
   run:
@@ -46,12 +54,20 @@ jobs:
         env:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_SHA: ${{ github.sha }}
+          GIT_AUTHOR_NAME: ${{ inputs.git_name }}
+          GIT_AUTHOR_EMAIL: ${{ inputs.git_email }}
+          GIT_COMMITTER_NAME: ${{ inputs.git_name }}
+          GIT_COMMITTER_EMAIL: ${{ inputs.git_email }}
         run: git commit -m "Deploy ${GITHUB_REF:11} [${GITHUB_SHA:0:7}]" --allow-empty
 
       - name: Commit the changes if ref is a tag
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_REF: ${{ github.ref }}
+          GIT_AUTHOR_NAME: ${{ inputs.git_name }}
+          GIT_AUTHOR_EMAIL: ${{ inputs.git_email }}
+          GIT_COMMITTER_NAME: ${{ inputs.git_name }}
+          GIT_COMMITTER_EMAIL: ${{ inputs.git_email }}
         run: git commit -m "Release ${GITHUB_REF:10}" --allow-empty
 
       - name: Push the changes

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -1,0 +1,58 @@
+name: Deploy via a git branch
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The target branch'
+        type: string
+        required: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  push-code:
+    name: 'Push branch to repo'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout the target branch, creating if necessary
+        run: git checkout ${{ inputs.branch }} || git checkout -b ${{ inputs.branch }}
+
+      - name: Update the code to the ref we are deploying
+        # Checkout of a target branch will only check out changes within that
+        # branch, which means removed files don't get removed. We handle that
+        # with a check and remove. We also use the sha specifically to avoid
+        # a subsequent push on a branch resulting in a different commit than
+        # intended.
+        run: |
+          git checkout ${{ github.sha }} -- .
+          git diff ${{ github.sha }} --name-only | xargs -r git rm
+
+      - name: Ensure everything matches before proceeding
+        run: |
+          git config --global --add safe.directory $(realpath .)
+          git diff ${{ inputs.directory }}
+          git diff-index --quiet HEAD -- ${{ inputs.directory }}
+
+      - name: Commit the changes if ref is a branch
+        if: startsWith(github.ref, 'refs/heads/')
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: git commit -m "Deploy ${GITHUB_REF:11} [${GITHUB_SHA:0:7}]" --allow-empty
+
+      - name: Commit the changes if ref is a tag
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_REF: ${{ github.ref }}
+        run: git commit -m "Release ${GITHUB_REF:10}" --allow-empty
+
+      - name: Push the changes
+        run: git push

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -15,6 +15,10 @@ on:
         description: 'The git committer email'
         type: string
         required: true
+    secrets:
+      GIT_ACCESS_TOKEN:
+        description: 'The write access token for the git repo.'
+        required: true
 
 defaults:
   run:
@@ -29,6 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Checkout the target branch, creating if necessary
         run: git checkout ${{ inputs.branch }} || git checkout -b ${{ inputs.branch }}

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -18,7 +18,19 @@ on:
     secrets:
       GIT_ACCESS_TOKEN:
         description: 'The write access token for the git repo.'
-        required: true
+        required: false
+      TARGET_REPO:
+        description: 'URL of the target repo.'
+        required: false
+      TARGET_SSH_KEY:
+        description: 'Private SSH key authorised to push to the target repo'
+        required: false
+      SSH_CONFIG:
+        description: 'SSH configuration'
+        required: false
+      KNOWN_HOSTS:
+        description: 'SSH known hosts'
+        required: false
 
 defaults:
   run:
@@ -29,11 +41,18 @@ jobs:
     name: 'Push branch to repo'
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the code
+      - name: Check out the code with a token
         uses: actions/checkout@v3
+        if: secrets.GIT_ACCESS_TOKEN
         with:
           fetch-depth: 0
           token: ${{ secrets.GIT_ACCESS_TOKEN }}
+
+      - name: Check out the code without a token
+        uses: actions/checkout@v3
+        if: ! secrets.GIT_ACCESS_TOKEN
+        with:
+          fetch-depth: 0
 
       - name: Checkout the target branch, creating if necessary
         run: git checkout ${{ inputs.branch }} || git checkout -b ${{ inputs.branch }}
@@ -75,5 +94,22 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ inputs.git_email }}
         run: git commit -m "Release ${GITHUB_REF:10}" --allow-empty
 
-      - name: Push the changes
+      - name: Push the branch to github
+        if: ! secrets.TARGET_REPO
         run: git push origin ${{ inputs.branch }}
+
+      - name: Set up the SSH key and configuration
+        if: secrets.TARGET_REPO
+        uses: shimataro/ssh-key-action@v2.3.1
+        with:
+          key: ${{ secrets.TARGET_SSH_KEY }}
+          config: ${{ secrets.SSH_CONFIG }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+
+      - name: Add the git remote
+        if: secrets.TARGET_REPO
+        run: git remote add target ${{ secrets.TARGET_REPO }}
+
+      - name: Push the branch to a remote
+        if: secrets.TARGET_REPO
+        run: git push target ${{ inputs.branch }}

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -7,14 +7,14 @@ on:
         description: 'The target branch'
         type: string
         required: false
-    git_name:
-      description: 'The git committer name'
-      type: string
-      required: true
-    git_email:
-      description: 'The git committer email'
-      type: string
-      required: true
+      git_name:
+        description: 'The git committer name'
+        type: string
+        required: true
+      git_email:
+        description: 'The git committer email'
+        type: string
+        required: true
 
 defaults:
   run:

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -10,7 +10,6 @@ on:
       remote_repo:
         description: 'Whether to push to a remote repo'
         type: boolean
-        required: true
         default: false
       git_name:
         description: 'The git committer name'

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Check out the code without a token
         uses: actions/checkout@v3
-        if: secrets.GIT_ACCESS_TOKEN == null
+        if: !${{ secrets.GIT_ACCESS_TOKEN }}
         with:
           fetch-depth: 0
 
@@ -95,7 +95,7 @@ jobs:
         run: git commit -m "Release ${GITHUB_REF:10}" --allow-empty
 
       - name: Push the branch to github
-        if: secrets.TARGET_REPO == null
+        if: !${{ secrets.TARGET_REPO }}
         run: git push origin ${{ inputs.branch }}
 
       - name: Set up the SSH key and configuration

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -50,9 +50,9 @@ jobs:
 
       - name: Ensure everything matches before proceeding
         run: |
-          git config --global --add safe.directory $(realpath .)
-          git diff ${{ inputs.directory }}
-          git diff-index --quiet HEAD -- ${{ inputs.directory }}
+          git config --global --add safe.directory $(realpath .) && echo 'config'
+          git diff ${{ inputs.directory }} && echo 'diff'
+          git diff-index --quiet HEAD -- ${{ inputs.directory }} && echo 'diff-index'
 
       - name: Commit the changes if ref is a branch
         if: startsWith(github.ref, 'refs/heads/')

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           git config --global --add safe.directory $(realpath .) && echo 'config'
           git diff && echo 'diff'
+          git diff-index HEAD && echo 'diff-index loud'
           git diff-index --quiet HEAD && echo 'diff-index'
 
       - name: Commit the changes if ref is a branch

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -6,7 +6,12 @@ on:
       branch:
         description: 'The target branch'
         type: string
-        required: false
+        required: true
+      remote_repo:
+        description: 'Whether to push to a remote repo'
+        type: boolean
+        required: true
+        default: false
       git_name:
         description: 'The git committer name'
         type: string
@@ -17,19 +22,19 @@ on:
         required: true
     secrets:
       GIT_ACCESS_TOKEN:
-        description: 'The write access token for the git repo.'
+        description: 'The write access token for the git repo. Required for github repo.'
         required: false
       TARGET_REPO:
-        description: 'URL of the target repo.'
+        description: 'URL of the target repo. Required for remote repo.'
         required: false
       TARGET_SSH_KEY:
-        description: 'Private SSH key authorised to push to the target repo'
+        description: 'Private SSH key authorised to push to the target repo. Required for remote repo.'
         required: false
       SSH_CONFIG:
-        description: 'SSH configuration'
+        description: 'SSH configuration. Required for remote repo.'
         required: false
       KNOWN_HOSTS:
-        description: 'SSH known hosts'
+        description: 'SSH known hosts. Required for remote repo.'
         required: false
 
 defaults:
@@ -43,14 +48,14 @@ jobs:
     steps:
       - name: Check out the code with a token
         uses: actions/checkout@v3
-        if: secrets.GIT_ACCESS_TOKEN
+        if: ${{ !inputs.remote_repo }}
         with:
           fetch-depth: 0
           token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Check out the code without a token
         uses: actions/checkout@v3
-        if: ${{ !secrets.GIT_ACCESS_TOKEN }}
+        if: ${{ inputs.remote_repo }}
         with:
           fetch-depth: 0
 
@@ -95,21 +100,19 @@ jobs:
         run: git commit -m "Release ${GITHUB_REF:10}" --allow-empty
 
       - name: Push the branch to github
-        if: ${{ !secrets.TARGET_REPO }}
+        if: ${{ !inputs.remote_repo }}
         run: git push origin ${{ inputs.branch }}
 
       - name: Set up the SSH key and configuration
-        if: secrets.TARGET_REPO
+        if: ${{ inputs.remote_repo }}
         uses: shimataro/ssh-key-action@v2.3.1
         with:
           key: ${{ secrets.TARGET_SSH_KEY }}
           config: ${{ secrets.SSH_CONFIG }}
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
 
-      - name: Add the git remote
-        if: secrets.TARGET_REPO
-        run: git remote add target ${{ secrets.TARGET_REPO }}
-
       - name: Push the branch to a remote
-        if: secrets.TARGET_REPO
-        run: git push target ${{ inputs.branch }}
+        if: ${{ inputs.remote_repo }}
+        run: |
+          git remote add target ${{ secrets.TARGET_REPO }}
+          git push target ${{ inputs.branch }}

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Ensure everything matches before proceeding
         run: |
           git config --global --add safe.directory $(realpath .) && echo 'config'
-          git diff ${{ inputs.directory }} && echo 'diff'
-          git diff-index --quiet HEAD -- ${{ inputs.directory }} && echo 'diff-index'
+          git diff && echo 'diff'
+          git diff-index --quiet HEAD && echo 'diff-index'
 
       - name: Commit the changes if ref is a branch
         if: startsWith(github.ref, 'refs/heads/')

--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Check out the code without a token
         uses: actions/checkout@v3
-        if: !${{ secrets.GIT_ACCESS_TOKEN }}
+        if: ${{ !secrets.GIT_ACCESS_TOKEN }}
         with:
           fetch-depth: 0
 
@@ -95,7 +95,7 @@ jobs:
         run: git commit -m "Release ${GITHUB_REF:10}" --allow-empty
 
       - name: Push the branch to github
-        if: !${{ secrets.TARGET_REPO }}
+        if: ${{ !secrets.TARGET_REPO }}
         run: git push origin ${{ inputs.branch }}
 
       - name: Set up the SSH key and configuration


### PR DESCRIPTION
This is useful for hosting platforms that use rolling branch deployments, e.g. Platform.sh and Vercel.

An example workflow that utilises this (in this case pushing to itself):

```
name: Deploy Frontend to Vercel
run-name: Deploying Frontend ${{github.ref_name}} to Vercel

on:
  workflow_dispatch:
    inputs:
      branch:
        type: choice
        description: Target environment
        options:
          - stage
          - prod
        required: true
        default: stage

# Wait for previous jobs to finish.
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}

jobs:
  deploy-branch:
    name: 'Deploy branch'
    # Ensure only tags get deployed.
    if: startsWith(github.ref, 'refs/tags/')
    uses: accessdigital/.github/.github/workflows/git-deploy-branch.yml@git-deploy-branch
    permissions:
      contents: write
    with:
      branch: ${{ inputs.branch }}
      git_name: ${{ github.event.sender.login }}
      git_email: ${{ github.event.sender.id }}+${{ github.event.sender.login }}@users.noreply.github.com
    secrets:
      GIT_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```