### PR TITLE
Minor fixes for bugs found during local updates.

### DIFF
--- a/.github/workflows/composer-security.yml
+++ b/.github/workflows/composer-security.yml
@@ -16,7 +16,6 @@ on:
         type: string
         default: 'composer'
 
-
 defaults:
   run:
     shell: bash
@@ -57,4 +56,5 @@ jobs:
 
       - name: Run security checks.
         run: |
+          git config --global --add safe.directory $(realpath .)
           composer require --dev --dry-run roave/security-advisories:@dev

--- a/.github/workflows/push-code.yml
+++ b/.github/workflows/push-code.yml
@@ -40,6 +40,10 @@ on:
         description: 'Additional options to pass to composer when removing dev dependencies'
         type: string
         default: '-o --apcu-autoloader'
+      dry_run:
+        description: 'Whether or not to actually push the code to the remote'
+        type: boolean
+        default: false
     secrets:
       ARTEFACT_REPO:
         description: 'URL of the artefact repo.'

--- a/.github/workflows/push-code.yml
+++ b/.github/workflows/push-code.yml
@@ -40,10 +40,6 @@ on:
         description: 'Additional options to pass to composer when removing dev dependencies'
         type: string
         default: '-o --apcu-autoloader'
-      dry_run:
-        description: 'Whether or not to actually push the code to the remote'
-        type: boolean
-        default: false
     secrets:
       ARTEFACT_REPO:
         description: 'URL of the artefact repo.'
@@ -74,7 +70,6 @@ jobs:
       COMMIT_MSG: ${{ github.event.head_commit.message }}
       COMMIT_SHA: ${{ github.sha }}
       COMMIT_REF: ${{ github.event.ref }}
-      DRY_RUN: ${{ inputs.dry_run == 'true' && '--dry-run' || '' }}
       GIT_AUTHOR_NAME: ${{ inputs.git_name }}
       GIT_AUTHOR_EMAIL: ${{ inputs.git_email }}
       GIT_COMMITTER_NAME: ${{ inputs.git_name }}


### PR DESCRIPTION
Couple of updates while removing BLT from a client site that requires we add the workflows directly into the codebase rather than using them from this repo: 

* The Composer security check was failing because the directory is not a safe directory. Copied in the command from `composer.yml`.
* The `push-code.yml` workflow was breaking for me originally because it didn't have the `dry-run` flag set as an input option.
  - Updated after discussion in Slack to remove the reference to `dry-run` completely as it "doesn't really make sense" in this workflow :) 