### PR TITLE
Skip git diff check when restoring from cache

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -138,7 +138,9 @@ jobs:
         run: npm --prefix "${{ inputs.directory }}" run build
 
       - name: Check for changes to committed code.
-        if: inputs.check_git
+        # Skip if we already have a full build.
+        if: (inputs.target_key == '' || steps.target-build.outputs.cache-hit != 'true') &&
+          inputs.check_git
         run: |
           git diff "${{ inputs.directory }}"
           git diff-index --quiet HEAD "${{ inputs.directory }}"


### PR DESCRIPTION
Currently, if an `npm` workflow build has been cached separately and later restored, the check for changes to committed code will fail due to not being able to find the git root.

See https://github.com/accessdigital/EdringtonDP/actions/runs/12068940341/job/33655126086 and https://github.com/accessdigital/SWBS-portal/actions/runs/12070145945/job/33658967723 for examples of this happening.

If the app has already been built once and cached with no issues then there is probably no benefit to checking again anyway, so we can skip the check when there is a valid cache hit.