### PR TITLE
Fixing git-deploy-branch failing if deleted filenames have spaces

### DIFF
--- a/.github/workflows/git-deploy-branch.yml
+++ b/.github/workflows/git-deploy-branch.yml
@@ -83,7 +83,7 @@ jobs:
         # intended.
         run: |
           git checkout ${{ github.sha }} -- .
-          git diff ${{ github.sha }} --name-only | xargs -r git rm
+          git diff ${{ github.sha }} --name-only | tr '\n' '\0' | xargs -0 -r git rm
 
       - name: Ensure everything matches before proceeding
         run: |


### PR DESCRIPTION
After some recent work moving around committed build assets on Macallan (see accessdigital/macallan2#1727) our deploy actions using `git-deploy-branch` have started to fail, for example https://github.com/accessdigital/macallan2/actions/runs/12376216422:

```
Run git checkout e3a86fb2a0646cc671f41aa9273806b96df84a3f -- .
  git checkout e3a86fb[2](https://github.com/accessdigital/macallan2/actions/runs/12376216422/job/34542816950#step:7:2)a0646cc671f41aa9273806b96df84a3f -- .
  git diff e3a86fb2a0646cc671f41aa927[3](https://github.com/accessdigital/macallan2/actions/runs/12376216422/job/34542816950#step:7:3)806b96df84a3f --name-only | xargs -r git rm
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
fatal: pathspec 'frontend/public/assets/macallan/images/icons/Macallan' did not match any files
```

It looks like the "Update the code to the ref we are deploying" step uses the command `git diff ${{ github.sha }} --name-only | xargs -r git rm` which isn't handling filenames which contain spaces.  
In our case it looks like the filename `frontend/public/assets/macallan/images/icons/Macallan Journey@2x.svg` was being interpreted as `frontend/public/assets/macallan/images/icons/Macallan` which then couldn't be found.

This fix updates that command to replace new line characters in the `git diff` output with a null character first, then adds the `-0` option of `xargs` so that the these null characters are used to split the output rather than whitespace, which includes spaces.