### PR TITLE
Update PHP version in Pantheon workflows

### DIFF
--- a/.github/workflows/pantheon-create-multidev.yml
+++ b/.github/workflows/pantheon-create-multidev.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Installing PHP
         uses: shivammathur/setup-php@master
         with:
-          php-version: '7.4'
+          php-version: '8.2'
 
       - name: Install Terminus.
         uses: pantheon-systems/terminus-github-actions@1.0.0

--- a/.github/workflows/pantheon-remove-branch.yml
+++ b/.github/workflows/pantheon-remove-branch.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Installing PHP
         uses: shivammathur/setup-php@master
         with:
-          php-version: '7.4'
+          php-version: '8.2'
 
       - name: Install Terminus.
         uses: kopepasah/setup-pantheon-terminus@master


### PR DESCRIPTION
Updating PHP version to 8.2 as Terminus no longer supports anything less.