### PR TITLE
Replace deprecated Terminus action

### DIFF
--- a/.github/workflows/pantheon-remove-branch.yml
+++ b/.github/workflows/pantheon-remove-branch.yml
@@ -64,7 +64,7 @@ jobs:
           php-version: '8.2'
 
       - name: Install Terminus.
-        uses: kopepasah/setup-pantheon-terminus@master
+        uses: pantheon-systems/terminus-github-actions@1.0.0
         with:
           pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
 


### PR DESCRIPTION
Turns out the remove branch workflow was still using an old deprecated action that doesn't support PHP 8.2.

Updated to the official Terminus action that is already used in the create multidev workflow. Looks like a straight replacement.