### PR TITLE
Update PHPUnit database to MariaDB 10.6.

### DIFF
--- a/.github/workflows/php-phpunit.yml
+++ b/.github/workflows/php-phpunit.yml
@@ -27,7 +27,7 @@ jobs:
     container: ${{ inputs.container }}
     services:
       db:
-        image: mysql:5.7
+        image: mariadb:10.6
         ports: [ 3306 ]
         env:
           MYSQL_USER: db


### PR DESCRIPTION
Now uses `mariadb:10.6` to reflect the database version set in DDEV currently/to work with Drupal 11.

Tested and working fine on SWBS. Not sure if any other sites use this workflow?

https://github.com/accessdigital/SWBS-portal/actions/runs/19269507791/job/55093878342?pr=1772 