### PR TITLE
Allow the database version to be passed as a parameter to the install workflow

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -7,6 +7,10 @@ on:
         description: 'The docker image to use'
         type: string
         required: true
+      db_container:
+        description: 'The MySQL version'
+        type: string
+        default: 'mariadb:10.3'
       source_key:
         description: 'The source cache key suffix'
         type: string
@@ -31,7 +35,7 @@ jobs:
     container: ${{ inputs.container }}
     services:
       db:
-        image: mariadb:10.3
+        image: ${{ inputs.db_container }}
         ports: [3306]
         env:
           MYSQL_USER: db


### PR DESCRIPTION
Now that Drupal sites are being updated to version 11 and MySQL 8, the site install workflow will fail because it's currently set to `mariadb:10.3` but the minimum version for Drupal 11 is MariaDB 10.6.

This change allows the database version to be passed in as a parameter, with the default set to still use MariaDB 10.3.